### PR TITLE
Ebuild improvements

### DIFF
--- a/app-emulation/wine-staging/metadata.xml
+++ b/app-emulation/wine-staging/metadata.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>wine@gentoo.org</email>
+		<name>Wine</name>
+		<description>
+			This package must be kept in sync with repo/proj/wine repository.
+			Any changes need to be run past the maintainer to ensure the two repositories are kept in sync.
+		</description>
+	</maintainer>
+	<longdescription>
+Wine is an Open Source implementation of the Windows API on top of X and Unix.
+
+Think of Wine as a compatibility layer for running Windows programs. Wine does not require Microsoft Windows, as it is a completely free alternative implementation of the Windows API consisting of 100% non-Microsoft code, however Wine can optionally use native Windows DLLs if they are available. Wine provides both a development toolkit for porting Windows source code to Unix as well as a program loader, allowing many unmodified Windows programs to run on x86-based Unixes, including Linux, FreeBSD, and Solaris.
+
+This variant of the Wine packaging includes the Wine-Staging patchset.
+	</longdescription>
+	<use>
+		<flag name="capi">Enable ISDN support via CAPI</flag>
+		<flag name="custom-cflags">Bypass strip-flags; use at your own peril</flag>
+		<flag name="dos">Pull in <pkg>games-emulation/dosbox</pkg> to run DOS applications</flag>
+		<flag name="ffmpeg">Use <pkg>media-video/ffmpeg</pkg> to decode WMA formats</flag>
+		<flag name="gecko">Add support for the Gecko engine when using iexplore</flag>
+		<flag name="gssapi">Use GSSAPI (Kerberos SSP support)</flag>
+		<flag name="gstreamer">Use <pkg>media-libs/gstreamer</pkg> to provide DirectShow functionality;</flag>
+		<flag name="mono">Add support for .NET using Wine's Mono add-on</flag>
+		<flag name="netapi">Use libnetapi from <pkg>net-fs/samba</pkg> to support Windows networks in netapi32.dll</flag>
+		<flag name="opencl">Enable OpenCL support</flag>
+		<flag name="osmesa">Add support for OpenGL in bitmaps using libOSMesa</flag>
+		<flag name="pcap">Support packet capture software (e.g. wireshark)</flag>
+		<flag name="perl">Install helpers written in perl (winedump/winemaker)</flag>
+		<flag name="pipelight">Apply Wine-Staging patches for Pipelight/Silverlight support</flag>
+		<flag name="prelink">Run prelink on DLLs during build;
+			For versions before wine-1.7.55 or hardened, do not disable if you do not know what this means as it can break things at runtime</flag>
+		<flag name="realtime">Pull in <pkg>sys-auth/rtkit</pkg> for low-latency pulseaudio support</flag>
+		<flag name="run-exes">Use Wine to open and run .EXE and .MSI files</flag>
+		<flag name="s3tc">Pull in <pkg>media-libs/libtxc_dxtn</pkg> for DXTn texture compression, needed for many games</flag>
+		<flag name="samba">Add support for NTLM auth. see
+		http://wiki.winehq.org/NtlmAuthSetupGuide and
+		http://wiki.winehq.org/NtlmSigningAndSealing</flag>
+		<flag name="sdl">Add support for gamepad detection using SDL</flag>
+		<flag name="staging">Apply Wine-Staging patches for advanced feature support that haven't made it into upstream Wine yet</flag>
+		<flag name="themes">Support GTK+:3 window theming through Wine-Staging</flag>
+		<flag name="udev">Use <pkg>virtual/libudev</pkg> to provide plug and play support</flag>
+		<flag name="vkd3d">Use <pkg>app-emulation/vkd3d</pkg> to provide Direct3D 12 support</flag>
+		<flag name="vulkan">Enable Vulkan drivers</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">wine-compholio/wine-staging</remote-id>
+		<remote-id type="sourceforge">wine</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/app-emulation/wine-vanilla/metadata.xml
+++ b/app-emulation/wine-vanilla/metadata.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>wine@gentoo.org</email>
+		<name>Wine</name>
+		<description>
+			This package must be kept in sync with repo/proj/wine repository.
+			Any changes need to be run past the maintainer to ensure the two repositories are kept in sync.
+		</description>
+	</maintainer>
+	<longdescription>
+Wine is an Open Source implementation of the Windows API on top of X and Unix.
+
+Think of Wine as a compatibility layer for running Windows programs. Wine does not require Microsoft Windows, as it is a completely free alternative implementation of the Windows API consisting of 100% non-Microsoft code, however Wine can optionally use native Windows DLLs if they are available. Wine provides both a development toolkit for porting Windows source code to Unix as well as a program loader, allowing many unmodified Windows programs to run on x86-based Unixes, including Linux, FreeBSD, and Solaris.
+
+This variant of the Wine packaging does not include external patchsets
+	</longdescription>
+	<use>
+		<flag name="capi">Enable ISDN support via CAPI</flag>
+		<flag name="custom-cflags">Bypass strip-flags; use at your own peril</flag>
+		<flag name="dos">Pull in <pkg>games-emulation/dosbox</pkg> to run DOS applications</flag>
+		<flag name="gecko">Add support for the Gecko engine when using iexplore</flag>
+		<flag name="gssapi">Use GSSAPI (Kerberos SSP support)</flag>
+		<flag name="gstreamer">Use <pkg>media-libs/gstreamer</pkg> to provide DirectShow functionality;</flag>
+		<flag name="mono">Add support for .NET using Wine's Mono add-on</flag>
+		<flag name="netapi">Use libnetapi from <pkg>net-fs/samba</pkg> to support Windows networks in netapi32.dll</flag>
+		<flag name="opencl">Enable OpenCL support</flag>
+		<flag name="osmesa">Add support for OpenGL in bitmaps using libOSMesa</flag>
+		<flag name="pcap">Support packet capture software (e.g. wireshark)</flag>
+		<flag name="perl">Install helpers written in perl (winedump/winemaker)</flag>
+		<flag name="prelink">Run prelink on DLLs during build;
+			For versions before wine-1.7.55 or hardened, do not disable if you do not know what this means as it can break things at runtime</flag>
+		<flag name="realtime">Pull in <pkg>sys-auth/rtkit</pkg> for low-latency pulseaudio support</flag>
+		<flag name="run-exes">Use Wine to open and run .EXE and .MSI files</flag>
+		<flag name="samba">Add support for NTLM auth. see
+		http://wiki.winehq.org/NtlmAuthSetupGuide and
+		http://wiki.winehq.org/NtlmSigningAndSealing</flag>
+		<flag name="sdl">Add support for gamepad detection using SDL</flag>
+		<flag name="udev">Use <pkg>virtual/libudev</pkg> to provide plug and play support</flag>
+		<flag name="vkd3d">Use <pkg>app-emulation/vkd3d</pkg> to provide Direct3D 12 support</flag>
+		<flag name="vulkan">Enable Vulkan drivers</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">wine-compholio/wine-staging</remote-id>
+		<remote-id type="sourceforge">wine</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/games-util/dxvk/dxvk-0.70.ebuild
+++ b/games-util/dxvk/dxvk-0.70.ebuild
@@ -2,95 +2,107 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
+
+MULTILIB_COMPAT=( abi_x86_{32,64} )
+
 inherit meson multilib-minimal
 
 DESCRIPTION="A Vulkan-based translation layer for Direct3D 10/11"
 HOMEPAGE="https://github.com/doitsujin/dxvk"
 
 if [[ ${PV} == "9999" ]] ; then
-        EGIT_REPO_URI="https://github.com/doitsujin/dxvk.git"
-        EGIT_BRANCH="master"
-        inherit git-r3
-        SRC_URI=""
+	EGIT_REPO_URI="https://github.com/doitsujin/dxvk.git"
+	EGIT_BRANCH="master"
+	inherit git-r3
+	SRC_URI=""
 else
-        SRC_URI="https://github.com/doitsujin/dxvk/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-        KEYWORDS="-* ~amd64 ~x86 ~x86-fbsd"
+	SRC_URI="https://github.com/doitsujin/dxvk/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="-* ~amd64"
 fi
 
 LICENSE="ZLIB"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 tests utils"
-
-REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )"
+IUSE="test utils"
 
 RESTRICT="test"
 
 RDEPEND="
-        || (
-		>=app-emulation/wine-vanilla-3.14:=[${MULTILIB_USEDEP},vulkan]
-		>=app-emulation/wine-staging-3.14:=[${MULTILIB_USEDEP},vulkan]
-		>=app-emulation/wine-d3d9-3.14:=[${MULTILIB_USEDEP},vulkan]
-		>=app-emulation/wine-any-3.14:=[${MULTILIB_USEDEP},vulkan]
+	|| (
+		>=app-emulation/wine-vanilla-3.14:*[${MULTILIB_USEDEP},vulkan]
+		>=app-emulation/wine-staging-3.14:*[${MULTILIB_USEDEP},vulkan]
+		>=app-emulation/wine-d3d9-3.14:*[${MULTILIB_USEDEP},vulkan]
+		>=app-emulation/wine-any-3.14:*[${MULTILIB_USEDEP},vulkan]
 	)
-"
+	utils? ( app-emulation/winetricks )"
 DEPEND="${RDEPEND}
-	>=sys-devel/gcc-7.3.0
-	dev-util/glslang
-	utils? (
-		app-emulation/winetricks
-	)
-"
+	dev-util/glslang"
 
 PATCHES=(
 	"${FILESDIR}/${P}-fix-32bit-build.patch"
 	"${FILESDIR}/${P}-winelib-fix.patch"
 )
 
+dxvk_check_requirements() {
+	if [[ ${MERGE_TYPE} != binary ]]; then
+		if ! tc-is-gcc || [[ $(gcc-major-version) -lt 7 || $(gcc-major-version) -eq 7 && $(gcc-minor-version) -lt 3 ]]; then
+			die "At least gcc 7.3 is required"
+		fi
+	fi
+}
+
+pkg_pretend() {
+	dxvk_check_requirements
+}
+
+pkg_setup() {
+	dxvk_check_requirements
+}
+
 multilib_src_configure() {
 	local emesonargs=(
-		--buildtype "release"
-		--prefix "${EPREFIX}/usr/$(get_libdir)"
+		--buildtype="release"
+		--prefix="${EPREFIX}/usr/$(get_libdir)"
 		--libdir="dxvk-${PV}"
 		--bindir="dxvk-${PV}/bin"
 		--datadir="dxvk-${PV}"
-		$(meson_use tests enable_tests)
-		--unity on
+		$(meson_use test enable_tests)
+		--unity=on
 	)
 	if [[ ${ABI} == amd64 ]]; then
 		emesonargs+=(
-			--cross-file "$S/build-wine64.txt"
+			--cross-file "${S}/build-wine64.txt"
 		)
 	else
 		emesonargs+=(
-			--cross-file "$S/build-wine32.txt"
+			--cross-file "${S}/build-wine32.txt"
 		)
 	fi
 	meson_src_configure
 
 	# Edit setup_dxvk.sh.in to work for specific variant
-	sed -e "/\/\.\.\/lib/s/.*//" -i ${BUILD_DIR}/utils/setup_dxvk.sh || die
-	sed -e "/dlls_dir=/s/.*/dlls_dir=${EPREFIX}\/usr\/$(get_libdir)\/dxvk-${PV}/" -i ${BUILD_DIR}/utils/setup_dxvk.sh || die
+	sed -e "/\/\.\.\/lib/s/.*//" -i "${BUILD_DIR}/utils/setup_dxvk.sh" || die
+	sed -e "/dlls_dir=/s/.*/dlls_dir=${EPREFIX}\/usr\/$(get_libdir)\/dxvk-${PV}/" -i "${BUILD_DIR}/utils/setup_dxvk.sh" || die
 }
 
 multilib_src_install() {
-    if use utils; then
-	# install winetricks verb
-	insinto ${EPREFIX}/usr/$(get_libdir)/dxvk-${PV}/bin
-	doins ${S}/utils/setup_dxvk.verb
+	if use utils; then
+		# install winetricks verb
+		insinto "/usr/$(get_libdir)/dxvk-${PV}/bin"
+		doins "${S}/utils/setup_dxvk.verb"
 
-	exeinto ${EPREFIX}/usr/$(get_libdir)/dxvk-${PV}/bin
-	doexe "${FILESDIR}/setup.sh"
-    fi
+		exeinto "/usr/$(get_libdir)/dxvk-${PV}/bin"
+		doexe "${FILESDIR}/setup.sh"
+	fi
 
 	# install DXVK setup healper script
-	dosym ${EPREFIX}/usr/$(get_libdir)/dxvk-${PV}/bin/setup_dxvk.sh ${EPREFIX}/usr/bin/dxvk-setup-${ABI}-${PV}
+	dosym "${EPREFIX}/usr/$(get_libdir)/dxvk-${PV}/bin/setup_dxvk.sh" "${EPREFIX}/usr/bin/dxvk-setup-${ABI}-${PV}"
 
 	# create combined setup helper
-	[ ! -f ${S}/dxvk-setup-${PV} ] && echo '#!/bin/sh' > ${S}/dxvk-setup-${PV}
-	echo dxvk-setup-${ABI}-${PV} '$@' >> ${S}/dxvk-setup-${PV}
+	[[ ! -f "${S}/dxvk-setup-${PV}" ]] && echo '#!/bin/sh' > "${S}/dxvk-setup-${PV}" || die
+	echo "dxvk-setup-${ABI}-${PV}" '$@' >> "${S}/dxvk-setup-${PV}" || die
 
-	exeinto ${EPREFIX}/usr/bin
-	doexe ${S}/dxvk-setup-${PV}
+	exeinto /usr/bin
+	doexe "${S}/dxvk-setup-${PV}"
 
 	meson_src_install
 }

--- a/games-util/dxvk/dxvk-9999.ebuild
+++ b/games-util/dxvk/dxvk-9999.ebuild
@@ -2,94 +2,104 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
+
+MULTILIB_COMPAT=( abi_x86_{32,64} )
+
 inherit meson multilib-minimal
 
 DESCRIPTION="A Vulkan-based translation layer for Direct3D 10/11"
 HOMEPAGE="https://github.com/doitsujin/dxvk"
 
 if [[ ${PV} == "9999" ]] ; then
-        EGIT_REPO_URI="https://github.com/doitsujin/dxvk.git"
-        EGIT_BRANCH="master"
-        inherit git-r3
-        SRC_URI=""
+	EGIT_REPO_URI="https://github.com/doitsujin/dxvk.git"
+	EGIT_BRANCH="master"
+	inherit git-r3
+	SRC_URI=""
 else
-        SRC_URI="https://github.com/doitsujin/dxvk/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-        KEYWORDS="-* ~amd64 ~x86 ~x86-fbsd"
+	SRC_URI="https://github.com/doitsujin/dxvk/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="-* ~amd64"
 fi
 
 LICENSE="ZLIB"
 SLOT="${PV}"
-IUSE="+abi_x86_32 +abi_x86_64 tests utils"
-
-REQUIRED_USE="|| ( abi_x86_32 abi_x86_64 )"
+IUSE="test utils"
 
 RESTRICT="test"
 
 RDEPEND="
-        || (
-		>=app-emulation/wine-vanilla-3.14:=[${MULTILIB_USEDEP},vulkan]
-		>=app-emulation/wine-staging-3.14:=[${MULTILIB_USEDEP},vulkan]
-		>=app-emulation/wine-d3d9-3.14:=[${MULTILIB_USEDEP},vulkan]
-		>=app-emulation/wine-any-3.14:=[${MULTILIB_USEDEP},vulkan]
+	|| (
+		>=app-emulation/wine-vanilla-3.14:*[${MULTILIB_USEDEP},vulkan]
+		>=app-emulation/wine-staging-3.14:*[${MULTILIB_USEDEP},vulkan]
+		>=app-emulation/wine-d3d9-3.14:*[${MULTILIB_USEDEP},vulkan]
+		>=app-emulation/wine-any-3.14:*[${MULTILIB_USEDEP},vulkan]
 	)
-"
+	utils? ( app-emulation/winetricks )"
 DEPEND="${RDEPEND}
-	>=sys-devel/gcc-7.3.0
-	dev-util/glslang
-	utils? (
-		app-emulation/winetricks
-	)
-"
+	dev-util/glslang"
 
-PATCHES=(
-	"${FILESDIR}/dxvk-0.70-winelib-fix.patch"
-)
+PATCHES=( "${FILESDIR}/${PN}-0.70-winelib-fix.patch" )
+
+dxvk_check_requirements() {
+	if [[ ${MERGE_TYPE} != binary ]]; then
+		if ! tc-is-gcc || [[ $(gcc-major-version) -lt 7 || $(gcc-major-version) -eq 7 && $(gcc-minor-version) -lt 3 ]]; then
+			die "At least gcc 7.3 is required"
+		fi
+	fi
+}
+
+pkg_pretend() {
+	dxvk_check_requirements
+}
+
+pkg_setup() {
+	dxvk_check_requirements
+}
 
 multilib_src_configure() {
 	local emesonargs=(
-		--buildtype "release"
-		--prefix "${EPREFIX}/usr/$(get_libdir)"
+		--buildtype="release"
+		--prefix="${EPREFIX}/usr/$(get_libdir)"
 		--libdir="dxvk-${PV}"
 		--bindir="dxvk-${PV}/bin"
 		--datadir="dxvk-${PV}"
-		$(meson_use tests enable_tests)
-		--unity on
+		$(meson_use test enable_tests)
+		--unity=on
 	)
 	if [[ ${ABI} == amd64 ]]; then
 		emesonargs+=(
-			--cross-file "$S/build-wine64.txt"
+			--cross-file "${S}/build-wine64.txt"
 		)
 	else
 		emesonargs+=(
-			--cross-file "$S/build-wine32.txt"
+			--cross-file "${S}/build-wine32.txt"
 		)
 	fi
 	meson_src_configure
 
 	# Edit setup_dxvk.sh.in to work for specific variant
-	sed -e "/\/\.\.\/lib/s/.*//" -i ${BUILD_DIR}/utils/setup_dxvk.sh || die
-	sed -e "/dlls_dir=/s/.*/dlls_dir=${EPREFIX}\/usr\/$(get_libdir)\/dxvk-${PV}/" -i ${BUILD_DIR}/utils/setup_dxvk.sh || die
+	sed -e "/\/\.\.\/lib/s/.*//" -i "${BUILD_DIR}/utils/setup_dxvk.sh" || die
+	sed -e "/dlls_dir=/s/.*/dlls_dir=${EPREFIX}\/usr\/$(get_libdir)\/dxvk-${PV}/" -i "${BUILD_DIR}/utils/setup_dxvk.sh" || die
 }
 
 multilib_src_install() {
-    if use utils; then
-	# install winetricks verb
-	insinto ${EPREFIX}/usr/$(get_libdir)/dxvk-${PV}/bin
-	doins ${S}/utils/setup_dxvk.verb
+	if use utils; then
+		# install winetricks verb
+		insinto "/usr/$(get_libdir)/dxvk-${PV}/bin"
+		doins "${S}/utils/setup_dxvk.verb"
 
-	exeinto ${EPREFIX}/usr/$(get_libdir)/dxvk-${PV}/bin
-	doexe "${FILESDIR}/setup.sh"
-    fi
+		exeinto "/usr/$(get_libdir)/dxvk-${PV}/bin"
+		doexe "${FILESDIR}/setup.sh"
+	fi
 
 	# install DXVK setup healper script
-	dosym ${EPREFIX}/usr/$(get_libdir)/dxvk-${PV}/bin/setup_dxvk.sh ${EPREFIX}/usr/bin/dxvk-setup-${ABI}-${PV}
+	dosym "${EPREFIX}/usr/$(get_libdir)/dxvk-${PV}/bin/setup_dxvk.sh" "${EPREFIX}/usr/bin/dxvk-setup-${ABI}-${PV}"
 
 	# create combined setup helper
-	[ ! -f ${S}/dxvk-setup-${PV} ] && echo '#!/bin/sh' > ${S}/dxvk-setup-${PV}
-	echo dxvk-setup-${ABI}-${PV} '$@' >> ${S}/dxvk-setup-${PV}
+	[[ ! -f "${S}/dxvk-setup-${PV}" ]] && echo '#!/bin/sh' > "${S}/dxvk-setup-${PV}" || die
+	echo "dxvk-setup-${ABI}-${PV}" '$@' >> "${S}/dxvk-setup-${PV}" || die
 
-	exeinto ${EPREFIX}/usr/bin
-	doexe ${S}/dxvk-setup-${PV}
+	exeinto /usr/bin
+	doexe "${S}/dxvk-setup-${PV}"
 
 	meson_src_install
 }

--- a/games-util/dxvk/metadata.xml
+++ b/games-util/dxvk/metadata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>pchome@something.com</email>
+		<name>pchome</name>
+	</maintainer>
+	<use>
+		<flag name="utils">Installs a verb used by <pkg>app-emulation/winetricks</pkg></flag>
+	</use>
+	<upstream>
+		<remote-id type="github">doitsujin/dxvk</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/profiles/arch/arm64/no-multilib/package.mask
+++ b/profiles/arch/arm64/no-multilib/package.mask
@@ -1,0 +1,1 @@
+games-util/dxvk 

--- a/profiles/default/linux/uclibc/amd64/package.mask
+++ b/profiles/default/linux/uclibc/amd64/package.mask
@@ -1,0 +1,1 @@
+games-util/dxvk 

--- a/profiles/hardened/linux/amd64/no-multilib/package.mask
+++ b/profiles/hardened/linux/amd64/no-multilib/package.mask
@@ -1,0 +1,1 @@
+games-util/dxvk 


### PR DESCRIPTION
**profiles: add package masks**
These aren't used in overlays, but if this package were to make
it in the main tree, then these files would be needed.

**wine-staging: add metadata.xml**

**wine-vanilla: add metadata.xml**

**dxvk: Ebuild fixes and tweaks**
-Add missing metadata.xml
-Use proper gcc detection
-remove x86 keyword as it's not supported on that arch.
-added quotes around variables
-reordered depends

I don't know enough about meson to know if I made the right changes in the configure section. You may need to double check that. If you want to know more about meson and proper settings, you can talk to Soap__ in #gentoo-proxy-maint on Freenode.

With these changes, this is the location of files:
```
$ equery f dxvk
 * Searching for dxvk ...
 * Contents of games-util/dxvk-0.70:
/usr
/usr/bin
/usr/bin/dxvk-setup-0.70
/usr/bin/dxvk-setup-amd64-0.70 -> /usr/lib64/dxvk-0.70/bin/setup_dxvk.sh
/usr/lib64
/usr/lib64/dxvk-0.70
/usr/lib64/dxvk-0.70/bin
/usr/lib64/dxvk-0.70/bin/setup_dxvk.sh
/usr/lib64/dxvk-0.70/d3d10.dll.so
/usr/lib64/dxvk-0.70/d3d10_1.dll.so
/usr/lib64/dxvk-0.70/d3d10core.dll.so
/usr/lib64/dxvk-0.70/d3d11.dll.so
/usr/lib64/dxvk-0.70/dxgi.dll.so
/usr/share
/usr/share/doc
/usr/share/doc/dxvk-0.70
/usr/share/doc/dxvk-0.70/README.md.bz2
```

I hope you like these changes. :)

Jon